### PR TITLE
Add rspec test for testing out uploading a hood

### DIFF
--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -43,8 +43,12 @@ end
 desc 'Upload a CSV of a neighborhood'
 task :upload_neighborhood, [:neighborhood_name, :neighborhood_zip_code, :neighborhood_data] => :environment do |t, args|
   starting_count = House.count
-  puts "There are #{starting_count} houses in the database."
-  puts "You have passed in #{args.count} arguments, with these keys: #{args.keys}"
+
+  Rails.logger.info <<~MSG.strip
+    There are #{starting_count} houses in the database.
+    You have passed in #{args.count} arguments, with these keys: #{args.keys}
+  MSG
+
   hood = Hood.find_or_create_by(name: args[:neighborhood_name], zip_code: args[:neighborhood_zip_code])
 
   args[:neighborhood_data].each do |row|
@@ -62,6 +66,8 @@ task :upload_neighborhood, [:neighborhood_name, :neighborhood_zip_code, :neighbo
   end
 
   ending_count = House.count
-  puts "There are #{ending_count} houses in the database now. That's #{ending_count-starting_count} more"
+  Rails.logger.info <<~MSG.strip
+    There are #{ending_count} houses in the database now (#{ending_count-starting_count} added)
+  MSG
 end
 

--- a/spec/tasks/scheduler_spec.rb
+++ b/spec/tasks/scheduler_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+require "rake"
+
+# Load all rake tasks once, available for re-use in each example
+Rails.application.load_tasks
+
+describe "scheduler.rake rake tasks" do
+  let(:task) { Rake::Task[task_name] }
+  let(:task_name) { "my:rake:task" }
+
+  after(:each) do
+    # Reset the task's `already_invoked` state, letting you
+    # re-execute the task with all dependencies
+    task.reenable 
+  end
+
+  describe "upload_neighborhood" do
+    let(:task_name) { "upload_neighborhood" }
+
+    let(:hood_name) { "Schitt's Creek" }
+    let(:hood_zip_code) { "13459" }
+
+    context "without neighborhood data" do
+      it "creates the neighborhood without houses" do
+        neighborhood_data = []
+
+        expect(Hood.find_by(name: hood_name)).to be_nil
+
+        expect { task.invoke(hood_name, hood_zip_code, neighborhood_data) }.not_to change { House.count }
+
+        expect(Hood.find_by(name: hood_name)).to be_an_instance_of(Hood)
+          .and have_attributes(name: hood_name, zip_code: hood_zip_code)
+      end
+    end
+
+    context "with neighborhood data" do
+      it "creates each house provided" do
+        expect(Hood.find_by(name: hood_name)).to be_nil
+        expect(House.count).to eq(0)
+
+        task.invoke("Schitt's Creek", "13459", [
+          ["8106 Muddy Pines Pl", "Tampa", "FL", "33635", "3", "2.5", "1872", "2"],
+          ["8108 Muddy Pines Pl", "Tampa", "FL", "33635", "3", "2.5", "1816", "1"],
+          ["8110 Muddy Pines Pl", "Tampa", "FL", "33635", "3", "2.5", "1584", "1"]
+        ])
+
+        hood = Hood.find_by(name: hood_name)
+        expect(hood).not_to be_nil
+        expect(hood.houses.count).to eq(3)
+        expect(hood.houses.map(&:address)).to include(
+          hash_including("city" => "Tampa", "state" => "FL", "street_address" => "8106 Muddy Pines Pl", "zip_code" => "33635"),
+          hash_including("city" => "Tampa", "state" => "FL", "street_address" => "8108 Muddy Pines Pl", "zip_code" => "33635"),
+          hash_including("city" => "Tampa", "state" => "FL", "street_address" => "8110 Muddy Pines Pl", "zip_code" => "33635"),
+        )
+      end
+    end
+  end
+end

--- a/spec/tasks/scheduler_spec.rb
+++ b/spec/tasks/scheduler_spec.rb
@@ -38,7 +38,7 @@ describe "scheduler.rake rake tasks" do
         expect(Hood.find_by(name: hood_name)).to be_nil
         expect(House.count).to eq(0)
 
-        task.invoke("Schitt's Creek", "13459", [
+        task.invoke("Schitt's Creek", "33634", [
           ["8106 Muddy Pines Pl", "Tampa", "FL", "33635", "3", "2.5", "1872", "2"],
           ["8108 Muddy Pines Pl", "Tampa", "FL", "33635", "3", "2.5", "1816", "1"],
           ["8110 Muddy Pines Pl", "Tampa", "FL", "33635", "3", "2.5", "1584", "1"]


### PR DESCRIPTION
This commit adds an rspec test for the `upload_neighborhood` rake task, so that it's a little easier to understand how to invoke the command.

## Next Steps

Ideally, we can change this to simply accept a CSV, and it will create both the neighborhood and the properties within it.