### PR TITLE
Capture update errors

### DIFF
--- a/app/services/valuation_collector.rb
+++ b/app/services/valuation_collector.rb
@@ -1,0 +1,23 @@
+class ValuationCollector
+  def initialize(house)
+    @house = house
+  end
+
+  def perform
+    raise ValuationCollectorError.new("House(id: #{@house.id}) does not have a zpid.") if @house.zpid.nil?
+
+    property = Rubillow::HomeValuation.zestimate({ zpid: @house.zpid })
+
+    if property.success?
+      @house
+        .add_valuation(Date.today, property.price)
+        .save!
+    else
+      raise ValuationCollectorError.new(<<~ERR.strip)
+        Could not update House(id: #{@house.id}). #{property.message}
+      ERR
+    end
+  end
+end
+
+class ValuationCollectorError < StandardError; end

--- a/spec/services/valuation_collector_spec.rb
+++ b/spec/services/valuation_collector_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+describe ValuationCollector do
+  describe "#perform" do
+    context "when a house does not have a zpid" do
+      it "raises an appropriate error" do
+        house = House.new
+
+        expect { described_class.new(house).perform }.to raise_error(
+          ValuationCollectorError,
+          a_string_including("does not have a zpid")
+        )
+      end
+    end
+
+    context "when a house has a zpid" do
+      context "on a successful update" do
+        it "saves the valuation to the house" do
+          mock_zpid = "sriracha-zpid"
+          hood = Hood.create
+          house = hood.houses.create
+          house.house_metadatum = HouseMetadatum.create(zpid: mock_zpid)
+
+          mock_response = instance_double(Rubillow::Models::SearchResult,
+                                          price: 20,
+                                          success?: true)
+
+          allow(Rubillow::HomeValuation).to receive(:zestimate).with({ zpid: mock_zpid }).and_return(mock_response)
+
+          expect(house.valuation_on(Date.today)).to eq(0)
+
+          described_class.new(house).perform
+
+          expect(house.valuation_on(Date.today)).to eq(20)
+        end
+      end
+
+      context "on a bad response from Rubillow client" do
+        it "raises an appropriate error" do
+          mock_zpid = "sriracha-zpid"
+          house = House.new
+          house.house_metadatum = HouseMetadatum.new(zpid: mock_zpid)
+
+          mock_response = instance_double(Rubillow::Models::SearchResult,
+                                          message: "Could not locate property or something",
+                                          success?: false)
+
+          allow(Rubillow::HomeValuation).to receive(:zestimate).with({ zpid: mock_zpid }).and_return(mock_response)
+
+          expect(house.valuation_on(Date.today)).to eq(0)
+
+          expect { described_class.new(house).perform }.to raise_error(
+            ValuationCollectorError,
+            a_string_including("Could not update House", "Could not locate property or something")
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request moves gathering a valuation for a house into it's own tested service.

We now handle the case when a house does not receive a proper response from the Zillow API. We currently don't have a way to send Sentry alerts, so there will need to be a follow up to install+configure Sentry.

**NOTE: This is based off of another branch which has more goodness/DRY code.**