### PR TITLE
Add sentry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,3 +58,4 @@ gem 'pry-rails'
 gem 'dotenv-rails', groups: [:development, :test]
 gem 'rubillow' # Zillow API Wrapper
 gem 'slack-ruby-client'
+gem 'sentry-ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,6 +200,13 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sentry-ruby (4.5.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      faraday (>= 1.0)
+      sentry-ruby-core (= 4.5.1)
+    sentry-ruby-core (4.5.1)
+      concurrent-ruby
+      faraday
     slack-ruby-client (0.17.0)
       faraday (>= 1.0)
       faraday_middleware
@@ -254,6 +261,7 @@ DEPENDENCIES
   rspec-rails
   rubillow
   sass-rails (~> 5.0)
+  sentry-ruby
   slack-ruby-client
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,6 @@
+Sentry.init do |config|
+  # if this environment variable is set, we don't need to have this file
+  # however, we're leaving it here to allow us to customize any settings for Sentry in the future
+  config.dsn = ENV["SENTRY_DSN"]
+  config.environment = Rails.env
+end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -7,7 +7,6 @@ task :house_valuation_collector => :environment do
       ValuationCollector.new(house).perform
     rescue ValuationCollectorError => e
       # report but do not stop from doing this for other properties
-      # TODO implement Sentry alerting
       Rails.logger.error e
       Sentry.capture_exception(e, extra: { house_id: house.id })
     end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -9,6 +9,7 @@ task :house_valuation_collector => :environment do
       # report but do not stop from doing this for other properties
       # TODO implement Sentry alerting
       Rails.logger.error e
+      Sentry.capture_exception(e, extra: { house_id: house.id })
     end
   end
 


### PR DESCRIPTION
This pull request installs the `sentry-ruby` client. The environment variables for this are currently set in Heroku, so this should be a simple deploy.

This pull request also updates the valuation collector to raise an error to sentry when we fail to update a house.

This addresses issues #41, #44 and #45. 