### PR TITLE
Publish monthly message once

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec'
   gem 'rspec-rails'
+  gem 'timecop'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,6 +226,7 @@ GEM
       sprockets (>= 3.0.0)
     thor (1.1.0)
     tilt (2.0.10)
+    timecop (0.9.4)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -265,6 +266,7 @@ DEPENDENCIES
   slack-ruby-client
   spring
   spring-watcher-listen (~> 2.0.0)
+  timecop
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,6 +58,12 @@ Rails.application.configure do
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
+  config.cache_store = :redis_cache_store, {
+    url: ENV["REDIS_URL"],
+    error_handler: -> (method: , returning: exception:) {
+      Sentry.capture_exception(exception, level: "warning", tags: { method: method, returning: returning })
+    }
+  }
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,7 +60,7 @@ Rails.application.configure do
   # config.cache_store = :mem_cache_store
   config.cache_store = :redis_cache_store, {
     url: ENV["REDIS_URL"],
-    error_handler: -> (method: , returning: exception:) {
+    error_handler: -> (method: , returning:, exception:) {
       Sentry.capture_exception(exception, level: "warning", tags: { method: method, returning: returning })
     }
   }

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,6 +6,7 @@ Rails.application.configure do
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
   config.cache_classes = true
+  config.cache_store = :null_store
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -26,5 +26,20 @@ end
 
 desc "Send monthly summary to Slack"
 task monthly_price_summary: :environment do
-  HappyHood::Slack::Client.send_monthly_price_summary
+  cache_key = "monthly_summary/#{Date.today.beginning_of_month}"
+  sent_message = false
+
+  Rails.cache.fetch(cache_key, expires_in: 1.month) do
+    HappyHood::Slack::Client.send_monthly_price_summary
+
+    sent_message = true
+  end
+
+  Rails.logger.info do
+    if sent_message
+      "Sent monthly summary for cache key: #{cache_key}"
+    else
+      "Already sent monthly summary. Skipping. Cache key: #{cache_key}"
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,4 +61,7 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.before(:suite) do
+    Rails.application.load_tasks
+  end
 end

--- a/spec/tasks/neighborhood_spec.rb
+++ b/spec/tasks/neighborhood_spec.rb
@@ -1,9 +1,6 @@
 require "rails_helper"
 require "rake"
 
-# Load all rake tasks once, available for re-use in each example
-Rails.application.load_tasks
-
 describe "neighborhood.rake rake tasks" do
   let(:task) { Rake::Task[task_name] }
   let(:task_name) { "my:rake:task" }

--- a/spec/tasks/scheduler_spec.rb
+++ b/spec/tasks/scheduler_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+require "rake"
+
+Rails.application.load_tasks
+
+describe "scheduler.rake rake tasks" do
+  let(:task) { Rake::Task[task_name] }
+  let(:task_name) { "my:rake:task" }
+
+  after(:each) do
+    task.reenable
+  end
+
+  describe "monthly_price_summary" do
+    let(:task_name) { "monthly_price_summary" }
+
+    it "sends a monthly price summary" do
+      expect(HappyHood::Slack::Client).to receive(:send_monthly_price_summary)
+
+      task.invoke
+    end
+
+    it "sends the monthly price summary only once per month" do
+      months = [3.months.ago, 1.month.ago]
+
+      months.each do |month|
+        Timecop.freeze(month) do
+          expect(HappyHood::Slack::Client).to receive(:send_monthly_price_summary).exactly(1).time
+
+          task.invoke
+          task.reenable
+        end
+      end
+    end
+  end
+end

--- a/spec/tasks/scheduler_spec.rb
+++ b/spec/tasks/scheduler_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 require "rake"
 
-Rails.application.load_tasks
-
 describe "scheduler.rake rake tasks" do
   let(:task) { Rake::Task[task_name] }
   let(:task_name) { "my:rake:task" }


### PR DESCRIPTION
This pull request uses Rails cache to ensure that we only publish the monthly summary once a month.

Since Heroku Scheduler does not support crontabs or setting up a job on a monthly basis, we have to ensure that the job is marked as completed most of the month.