### PR TITLE
Use ERB to render a summary instead

### DIFF
--- a/app/services/difference_renderer.rb
+++ b/app/services/difference_renderer.rb
@@ -16,38 +16,46 @@ class DifferenceRenderer
   end
 
   def render
-    average_house_difference = if @difference.average_house_difference
-                                 avg_diff_string = if @difference.average_house_difference.positive?
-                                                     "+#{number_to_currency(@difference.average_house_difference)}"
-                                                   else
-                                                     number_to_currency(@difference.average_house_difference)
-                                                   end
-
-                                 "(#{avg_diff_string} avg/house)"
-                               end
-
-    difference = if @difference.valuation_difference.positive?
-                   "+#{@difference.valuation_difference}"
-                 else
-                   @difference.valuation_difference
-                 end
-
-    time_ago_string = "(#{time_ago_in_words(@difference.earliest_valuation_date + 1.day)} ago)" unless @difference.earliest_valuation_date.nil?
-
-    <<~SUMMARY.strip
-      ```
-      #{@difference.hood_name} (#{@difference.house_count} Happy #{"House".pluralize(@difference.house_count)})
-
-      #{short_date_format(@difference.earliest_valuation_date)}: #{number_to_currency(@difference.earliest_valuation)} #{time_ago_string}
-      #{short_date_format(@difference.latest_valuation_date)}: #{number_to_currency(@difference.latest_valuation)}
-      Difference:   #{number_to_currency(difference)} #{average_house_difference}
-      ```
-    SUMMARY
+    ERB
+      .new(File.read(template_path), trim_mode: "%<>")
+      .result_with_hash(erb_hash)
   end
 
   private
 
+  def erb_hash
+    average_house_difference = if @difference.average_house_difference
+                                 avg_diff_string = number_to_currency_with_direction_indicator(@difference.average_house_difference)
+                                 "(#{avg_diff_string} avg/house)"
+                               end
+
+    {
+      hood_name: @difference.hood_name,
+      house_count: @difference.house_count,
+      house_or_houses: "House".pluralize(@difference.house_count),
+      latest_valuation_date: short_date_format(@difference.latest_valuation_date),
+      latest_valuation: number_to_currency(@difference.latest_valuation),
+      difference_in_currency: number_to_currency(@difference.valuation_difference),
+      earliest_valuation_date: @difference.earliest_valuation_date ? short_date_format(@difference.earliest_valuation_date) : nil,
+      earliest_valuation: @difference.earliest_valuation ? number_to_currency(@difference.earliest_valuation) : nil,
+      time_ago_since_earliest_valuation: @difference.earliest_valuation_date ? "(#{time_ago_in_words(@difference.earliest_valuation_date + 1.day)} ago)" : nil,
+      average_house_difference: average_house_difference,
+    }
+  end
+
+  def template_path
+    Rails.root.join("app", "views", "templates", "difference_summary.md.erb")
+  end
+
   def short_date_format(date)
     date.strftime(SHORT_DATE_FORMAT)
+  end
+
+  def number_to_currency_with_direction_indicator(number)
+    if number.positive?
+      "+#{number_to_currency(number)}"
+    else
+      number_to_currency(number)
+    end
   end
 end

--- a/app/views/templates/difference_summary.md.erb
+++ b/app/views/templates/difference_summary.md.erb
@@ -1,0 +1,9 @@
+<%= hood_name %> (<%= house_count %> Happy <%= house_or_houses %>)
+
+<% if earliest_valuation_date %>
+<%= earliest_valuation_date %>: <%= earliest_valuation %> <%= time_ago_since_earliest_valuation %>
+<% end %>
+
+<%= latest_valuation_date %>: <%= latest_valuation %>
+
+Difference:   <%= difference_in_currency %> <%= average_house_difference %>

--- a/spec/services/difference_renderer_spec.rb
+++ b/spec/services/difference_renderer_spec.rb
@@ -57,6 +57,31 @@ describe DifferenceRenderer do
         end
       end
 
+      context "when a neighborhood that was just added has houses partially valuated" do
+        it "posts a message without yesterday included" do
+          hood.houses.new
+            .add_valuation(Date.today, 24)
+            .save!
+
+          hood.houses.new
+            .add_valuation(12.days.ago, 20)
+            .add_valuation(Date.today, 24)
+            .save!
+
+          difference = HoodDifference.build_for(hood, start_date: 1.day.ago, end_date: Date.today)
+          rendered_diff = described_class.summarize_differences([difference])
+
+          expect(rendered_diff).to match(
+            a_string_including(
+              hood.name,
+              "#{Date.today.strftime("%b %d, %Y")}: $48.00",
+              "Difference:   $48.00",
+              "(+$24.00 avg/house)",
+            )
+          )
+        end
+      end
+
       context "when a neighborhood has houses that were valuated prior to yesterday and valuated today" do
         it "posts a message with the delta" do
           # The case when we stopped updating house prices for some reason


### PR DESCRIPTION
We had an issue where the summary was not being rendered. It was really hard to debug what went wrong.

By having a way of generating a hash of data, we will be able to more accurately inspect what went wrong.

Additionally, it just makes rendering a template much easier.