### PR TITLE
Split up daily into task

### DIFF
--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -11,8 +11,6 @@ task house_valuation_collector: :environment do
       Sentry.capture_exception(e, extra: { house_id: house.id })
     end
   end
-
-  HappyHood::Slack::Client.send_daily_price_summary
 end
 
 desc 'Ping Zillow to get property zpid'

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -23,23 +23,3 @@ task collect_zpids: :environment do
 
   Rails.logger.info { "Updated #{result.updated_count} out of #{result.total_houses} without zpids." }
 end
-
-desc "Send monthly summary to Slack"
-task monthly_price_summary: :environment do
-  cache_key = "monthly_summary/#{Date.today.beginning_of_month}"
-  sent_message = false
-
-  Rails.cache.fetch(cache_key, expires_in: 1.month) do
-    HappyHood::Slack::Client.send_monthly_price_summary
-
-    sent_message = true
-  end
-
-  Rails.logger.info do
-    if sent_message
-      "Sent monthly summary for cache key: #{cache_key}"
-    else
-      "Already sent monthly summary. Skipping. Cache key: #{cache_key}"
-    end
-  end
-end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,5 +1,3 @@
-require 'happy_hood/slack/client'
-
 desc 'Collect Zillow Zestimate for each House'
 task house_valuation_collector: :environment do
   House.find_each do |house|

--- a/lib/tasks/summaries.rake
+++ b/lib/tasks/summaries.rake
@@ -1,0 +1,23 @@
+require "happy_hood/slack/client"
+
+namespace :summaries do
+  desc "Send monthly summary to Slack"
+  task monthly: :environment do
+    cache_key = "monthly_summary/#{Date.today.beginning_of_month}"
+    sent_message = false
+
+    Rails.cache.fetch(cache_key, expires_in: 1.month) do
+      HappyHood::Slack::Client.send_monthly_price_summary
+
+      sent_message = true
+    end
+
+    Rails.logger.info do
+      if sent_message
+        "Sent monthly summary for cache key: #{cache_key}"
+      else
+        "Already sent monthly summary. Skipping. Cache key: #{cache_key}"
+      end
+    end
+  end
+end

--- a/lib/tasks/summaries.rake
+++ b/lib/tasks/summaries.rake
@@ -1,6 +1,26 @@
 require "happy_hood/slack/client"
 
 namespace :summaries do
+  desc "Send daily summary to Slack"
+  task daily: :environment do
+    cache_key = "daily_summary/#{Date.today}"
+    sent_message = false
+
+    Rails.cache.fetch(cache_key, expires_in: 1.day) do
+      HappyHood::Slack::Client.send_daily_price_summary
+
+      sent_message = true
+    end
+
+    Rails.logger.info do
+      if sent_message
+        "Sent summary for cache key: #{cache_key}"
+      else
+        "Already sent summary. Skipping. Cache key: #{cache_key}"
+      end
+    end
+  end
+
   desc "Send monthly summary to Slack"
   task monthly: :environment do
     cache_key = "monthly_summary/#{Date.today.beginning_of_month}"

--- a/spec/tasks/scheduler_spec.rb
+++ b/spec/tasks/scheduler_spec.rb
@@ -8,36 +8,4 @@ describe "scheduler.rake rake tasks" do
   after(:each) do
     task.reenable
   end
-
-  describe "monthly_price_summary" do
-    let(:task_name) { "monthly_price_summary" }
-
-    it "sends a monthly price summary" do
-      expect(HappyHood::Slack::Client).to receive(:send_monthly_price_summary)
-
-      task.invoke
-    end
-
-    context "with caching enabled" do
-      before do
-        file_store_cache = ActiveSupport::Cache.lookup_store(:file_store, "tmp/test#{ENV["TEST_ENV_NUMBER"]}/cache")
-        allow(Rails).to receive(:cache).and_return(file_store_cache)
-        Rails.cache.clear
-      end
-      it "sends the monthly price summary only once per month" do
-        months = [3.months.ago, 1.month.ago]
-
-        months.each do |month|
-          Timecop.freeze(month) do
-            expect(HappyHood::Slack::Client).to receive(:send_monthly_price_summary).exactly(1).time
-
-            2.times do
-              task.invoke
-              task.reenable
-            end
-          end
-        end
-      end
-    end
-  end
 end

--- a/spec/tasks/summaries_spec.rb
+++ b/spec/tasks/summaries_spec.rb
@@ -4,6 +4,7 @@ require "rake"
 describe "summaries.rake rake tasks" do
   let(:task) { Rake::Task[task_name] }
   let(:task_name) { "my:rake:task" }
+  let(:file_store_name) { "tmp/test_#{RSpec.current_example.metadata[:description].gsub(/\W+/, "_")[0..28]}/cache" }
 
   after(:each) do
     task.reenable
@@ -20,7 +21,7 @@ describe "summaries.rake rake tasks" do
 
     context "with caching enabled" do
       before do
-        file_store_cache = ActiveSupport::Cache.lookup_store(:file_store, "tmp/test#{ENV["TEST_ENV_NUMBER"]}/cache")
+        file_store_cache = ActiveSupport::Cache.lookup_store(:file_store, file_store_name)
         allow(Rails).to receive(:cache).and_return(file_store_cache)
         Rails.cache.clear
       end
@@ -47,7 +48,7 @@ describe "summaries.rake rake tasks" do
 
     context "with caching enabled" do
       before do
-        file_store_cache = ActiveSupport::Cache.lookup_store(:file_store, "tmp/test#{ENV["TEST_ENV_NUMBER"]}/cache")
+        file_store_cache = ActiveSupport::Cache.lookup_store(:file_store, file_store_name)
         allow(Rails).to receive(:cache).and_return(file_store_cache)
         Rails.cache.clear
       end

--- a/spec/tasks/summaries_spec.rb
+++ b/spec/tasks/summaries_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+require "rake"
+
+describe "summaries.rake rake tasks" do
+  let(:task) { Rake::Task[task_name] }
+  let(:task_name) { "my:rake:task" }
+
+  after(:each) do
+    task.reenable
+  end
+
+  describe "monthly" do
+    let(:task_name) { "summaries:monthly" }
+
+    it "sends a monthly price summary" do
+      expect(HappyHood::Slack::Client).to receive(:send_monthly_price_summary)
+
+      task.invoke
+    end
+
+    context "with caching enabled" do
+      before do
+        file_store_cache = ActiveSupport::Cache.lookup_store(:file_store, "tmp/test#{ENV["TEST_ENV_NUMBER"]}/cache")
+        allow(Rails).to receive(:cache).and_return(file_store_cache)
+        Rails.cache.clear
+      end
+      it "sends the monthly price summary only once per month" do
+        months = [3.months.ago, 1.month.ago]
+
+        months.each do |month|
+          Timecop.freeze(month) do
+            expect(HappyHood::Slack::Client).to receive(:send_monthly_price_summary).exactly(1).time
+
+            2.times do
+              task.invoke
+              task.reenable
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request removes sending the daily summary from the rake task that gather house valuations, and moves it into it's own task.

This will allow us to move the house valuation collector to an earlier time, and stagger the summaries together.