### PR TITLE
Add happy_network to application

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,9 @@
 version: '3.4'
 
+networks:
+  happy_software:
+    name: happy_network
+
 x-main: &main
   tty: true
   stdin_open: true
@@ -14,6 +18,9 @@ x-main: &main
     DB_PASSWORD: postgres
     ONBOARDING_TOKEN: fake123
     HAPPY_HOUSE_API_TOKEN: fake123
+  networks:
+    - default
+    - happy_software
   depends_on:
     - postgres
     - redis


### PR DESCRIPTION
This pull request enforces that the application use the `happy_network` docker network. If it does not exist, it creates it.

Example usage:

```shell
# In one terminal, go into happy hood and spin up the network
# create the `happy_network` if it doesn't exist. Join `happy_network`.
dip compose up

# In another terminal, go into happy house and spin up the network
# create the `happy_network` if it doesn't exist. Join `happy_network`.
dip compose up

# Once both are running, you can use a new terminal window to confirm networking:

curl 127.0.0.1:3000
curl 127.0.0.1:3001
```